### PR TITLE
magix3d crashes when importing a non-builtin module in the python console

### DIFF
--- a/src/QtPython3/QtPythonConsole.cpp
+++ b/src/QtPython3/QtPythonConsole.cpp
@@ -655,8 +655,8 @@ static int tracePythonExecution (PyObject*, PyFrameObject* frame, int what, PyOb
 		else if (PyTrace_EXCEPTION == what)	// Ligne en erreur
 		{
 			PyObject*		pystring = PyObject_Str (obj);
-			Py_DecRef (pystring);
 			const string	error= PyUnicode_AsUTF8 (pystring);
+            Py_DecRef (pystring);
 			QtPythonConsole &console = getConsole (*frame);
 			console.lineProcessedCallback (PyUnicode_AsUTF8 (frame->f_code->co_filename), PyFrame_GetLineNumber (frame), false, error);
 		}	// if (PyTrace_EXCEPTION == what)


### PR DESCRIPTION
Does not occur when using magix3d as a python library, only happens in the python console.

To reproduce, try to import `numpy` in the python console (with `+pythonaddon` activated if compiling using spack).
The debugger stops in a call to 
`PyUnicode_AsUTF8` at https://github.com/LIHPC-Computational-Geometry/qtpython/blob/main/src/QtPython3/QtPythonConsole.cpp#L659

Displacing the call to `PyDecRef` to after the object is used seems to avoid the crash.

It also allows the import to succeed, which I have no idea why, since from my understanding of the comments if we are in this part it means that the import failed.